### PR TITLE
Fix faulty menu code

### DIFF
--- a/PantheonsHitCounter/ModMenu.cs
+++ b/PantheonsHitCounter/ModMenu.cs
@@ -124,7 +124,7 @@ namespace PantheonsHitCounter {
                 }, out _
             );
             
-            l.x = new RelLength(1920f);
+            l.x = new RelLength(0f);
             layout.ChangeColumns(1, 0.25f, l);
             
             area.AddTextPanel("Note",


### PR DESCRIPTION
Although the old value didn't break the current menu, if you (in the future) or someone else (in some other mod) changes Columns again for a second time it will break. Hence why the change is needed.

(This probably doesn't need to be  updated on scarab as current menu doesn't have a problem)